### PR TITLE
Update Python versions that notebooks are tested against

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         uv pip install --system .
-        uv pip install --system nbconvert ipykernel
+        uv pip install --system nbconvert ipykernel matplotlib
     
     - name: Find and run notebooks
       run: |

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
I set a minimum Python version requirement of 3.11 in the pyproject.toml file, but this was inconsistent with the Python versions that are tested in the Github action.

This PR makes it consistent, so Python versions 3.11, 3.12, and 3.13 are tested with the notebooks included in the repository.