### PR TITLE
remove reference to nonexistent directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following variables are recognized in rate expressions:
 
 ## Examples
 
-Example network files can be found in the `examples/example_networks/` directory.
+Example network files can be found in the `networks/` directory.
 
 ## Development
 


### PR DESCRIPTION
I accidentally referred to a nonexistent directory in the text that I added to the README file. Fixed in this PR.