### PR TITLE
add scipy to testing environment

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         uv pip install --system .
-        uv pip install --system nbconvert ipykernel matplotlib
+        uv pip install --system nbconvert ipykernel matplotlib scipy
     
     - name: Find and run notebooks
       run: |


### PR DESCRIPTION
Adds `scipy` to the python environment that is used to test the Python notebooks.