### PR TITLE
remove non-working example code from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,8 @@ After installation, you can use the `jaff` command:
 # Load and validate a network file
 jaff networks/gas_reactions_kida.uva.2024.in
 
-# Check mass and charge conservation
-jaff networks/react_COthin --check-mass --check-charge
-
 # List all species and reactions
 jaff networks/test.dat --list-species --list-reactions
-
-# Exit on validation errors
-jaff network_file.dat --errors
 ```
 
 ### Python API Usage
@@ -45,7 +39,7 @@ jaff network_file.dat --errors
 from jaff import Network
 
 # Load a chemical network
-network = Network("path/to/network_file.dat")
+network = Network("networks/react_COthin")
 
 # Access species
 for species in network.species:
@@ -53,14 +47,7 @@ for species in network.species:
 
 # Access reactions
 for reaction in network.reactions:
-    print(f"{reaction}")
-    
-# Check conservation laws
-network.check_mass(errors=False)
-network.check_charge(errors=False)
-
-# Generate ODEs for the network
-odes = network.get_odes()
+    print(f"{reaction.get_sympy()}")
 ```
 
 ## Features


### PR DESCRIPTION
Some of the example code in the README did not work. This removes the non-working code.