### PR TITLE
Fix issue with lambdify not working properly with vectors

### DIFF
--- a/src/jaff/network.py
+++ b/src/jaff/network.py
@@ -619,7 +619,12 @@ class Network:
             elif f is None:
                 rates[i,:] = np.nan
             else:
-                rates[i,:] = np.clip(f(temp),
+                # Note: it would be much faster to do this via an array operation
+                # rather than a list comprehension, but sympy (as of v1.13) does
+                # not consistently generate numpy expressions that work properly
+                # with vector inputs, so restricting the input to scalars is safer.
+                f_eval = np.array([f(t) for t in temp])
+                rates[i,:] = np.clip(f_eval,
                                      a_min = None, a_max = rate_max)
 
         # Fifth step: do adaptive growth of table
@@ -648,7 +653,10 @@ class Network:
                         rates_grow[i,1::2] = np.nan
                         rates_approx[i,:] = np.nan
                     else:
-                        rates_grow[i,1::2] = np.clip(f(temp_grow[1::2]),
+                        # See comment above about why we're using a list comprehension
+                        # here instead of a straight array operation
+                        f_eval = np.array([f(t) for t in temp_grow[1::2]])
+                        rates_grow[i,1::2] = np.clip(f_eval,
                                                      a_min = None,
                                                      a_max = rate_max)
                         rates_approx[i,:] = np.sqrt(rates_grow[i,:-1:2] *

--- a/src/jaff/reaction.py
+++ b/src/jaff/reaction.py
@@ -137,9 +137,9 @@ class Reaction:
         import numpy as np
 
         if self.tmin is None:
-            tmin = self.tmin
-        else:
             tmin = 2.73
+        else:
+            tmin = self.tmin
         if self.tmax is None:
             tmax = 1e6
         else:

--- a/src/jaff/reaction.py
+++ b/src/jaff/reaction.py
@@ -136,7 +136,15 @@ class Reaction:
         import matplotlib.pyplot as plt
         import numpy as np
 
-        tgas = np.linspace(self.tmin, self.tmax, 100)
+        if self.tmin is None:
+            tmin = self.tmin
+        else:
+            tmin = 2.73
+        if self.tmax is None:
+            tmax = 1e6
+        else:
+            tmax = self.tmax
+        tgas = np.logspace(tmin, tmax, 100)
         r = sympy.lambdify('tgas', self.rate, 'numpy')
         y = np.array([r(t) for t in tgas])
 

--- a/src/jaff/reaction.py
+++ b/src/jaff/reaction.py
@@ -138,7 +138,7 @@ class Reaction:
 
         tgas = np.linspace(self.tmin, self.tmax, 100)
         r = sympy.lambdify('tgas', self.rate, 'numpy')
-        y = r(tgas)
+        y = np.array([r(t) for t in tgas])
 
         if ax is None:
             _, ax = plt.subplots()


### PR DESCRIPTION
Sympy lambdify seems to have problems generating code that works properly with numpy vector operations in some circumstances, so I have reverted to handling evaluations when operating on tabulated expressions using list comprehensions. This is slower but safer.