### PR TITLE
add LICENSE and CONTRIBUTING.md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to JAFF
+
+Welcome! We're excited that you're interested in contributing to JAFF (Just Another Fancy Format), an astrochemical network parser.
+
+PLEASE NOTE:
+If you choose to make contributions to the code, you hereby grant a non-exclusive, royalty-free perpetual license
+to install, use, modify, prepare derivative works, incorporate into other computer software,
+distribute, and sublicense such enhancements or derivative works thereof, in binary and source code form.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR-USERNAME/jaff.git`
+3. Create a new branch: `git checkout -b your-feature-name`
+4. Install the package in development mode: `uv pip install -e ".[dev]"`
+
+## Development Process
+
+### Code Style
+- Match the style and formatting of surrounding code
+- Keep solutions simple, clean, and maintainable
+- Each code file should start with a 2-line comment beginning with "ABOUTME: "
+- Preserve existing comments unless they are demonstrably false
+
+### Making Changes
+1. Make the smallest reasonable changes to achieve your goal
+2. Write tests BEFORE implementing new features (Test-Driven Development)
+3. Ensure all tests pass before submitting
+4. Commit frequently with clear, descriptive messages
+
+### Testing
+All contributions should include:
+- Unit tests for individual components
+- An example Python notebook in `examples/` demonstrating your feature
+
+Run tests with: `uv run pytest` (once test framework is set up)
+
+### Submitting Changes
+1. Push your branch to your fork
+2. Create a Pull Request with:
+   - Clear description of the changes
+   - Reference to any related issues
+   - Test results showing all tests pass
+3. Address any review feedback promptly
+
+## Questions?
+
+Open an issue for:
+- Bug reports
+- Feature requests
+- Questions about the codebase
+- Discussion of potential contributions
+
+Thank you for contributing to JAFF!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2025 Jaff Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This PR adopts the [MIT open-source license](https://opensource.org/license/mit), which reads in full:
```
Copyright 2025 Jaff Contributors

Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
 permit persons to whom the Software is furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
 BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
```

Adoption of an [OSI-approved license](https://opensource.org/licenses) is required to submit to the Journal of Open Source Software.

The reason I propose adopting the MIT license among the OSI-approved licenses is because it is very short and easily readable, is very popular among many open-source software packages, and ensures that copyright law will not interfere will collaborating on the software while protecting the contributors to the software from liability.

**Since all existing code needs to be provided by all contributors to the code under this license, this requires agreement from all of the people who have contributed to this repository: @BenWibking @markkrumholz @tgrassi @GijsVermarien @psharda. Please leave a comment below in this PR if you agree to license your contribution to jaff under the MIT license.** Thanks!