### PR TITLE
Change HDF5 output format to write reaction names

### DIFF
--- a/src/jaff/network.py
+++ b/src/jaff/network.py
@@ -968,7 +968,11 @@ class Network:
                 grp.attrs['spacing'] = ['log']
 
             # Store information on which reactions / rate coefficients
-            # are included
+            # are included; note that we store these as data sets
+            # instead of attributes to avoid problems in the case where
+            # the number of reactions is very large, and thus resulting
+            # size of the output reaction list exceeds the HDF5 limit
+            # on the sizes of attributes
             output_names = []
             output_units = []
             for i, rt, r, p in zip(range(len(rtype)), rtype, 
@@ -978,8 +982,8 @@ class Network:
                     format(str(rt), str(r), str(p))
                 )
                 output_units.append('cm^3 s^-1')
-            grp.attrs['output_names'] = output_names
-            grp.attrs['output_units'] = output_units
+            grp.create_dataset('output_names', data=output_names, dtype=h5py.string_dtype())
+            grp.create_dataset('output_units', data=output_units, dtype=h5py.string_dtype())
 
             # Create data set holding the coefficient table
             dset = grp.create_dataset('data', data=coef)


### PR DESCRIPTION
Store reaction names and units to a data set rather than an attribute in HDF5 output