### PR TITLE
fix bugs in 2b6c8ac

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-jaff = ["data/*.dat"]
+jaff = ["data/*.dat", "templates/**/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.0.0",
-    "scipy>=1.14.0",
+    "scipy>=1.13.0",
     "sympy>=1.14.0",
     "tqdm>=4.67.1",
     "h5py>=3.9.0",

--- a/src/jaff/templates/fortran_dlsodes/Makefile
+++ b/src/jaff/templates/fortran_dlsodes/Makefile
@@ -53,6 +53,27 @@ obj_main = main.o
 all:	$(objs) $(obj_main)
 	$(fc) $(fswitch) $(objs) $(obj_main) -o $(exe) $(lib)
 
+# Module dependencies
+# commons module is used by reactions, fluxes, ode, and main
+reactions.o: reactions.f90 commons.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# fluxes module uses commons and reactions
+fluxes.o: fluxes.f90 commons.o reactions.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# ode module uses commons and fluxes
+ode.o: ode.f90 commons.o fluxes.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# main uses commons and ode
+main.o: main.f90 commons.o ode.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# commons has no dependencies
+commons.o: commons.f90
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
 #full debug target
 debug: fswitch = $(switchDBG)
 debug: all


### PR DESCRIPTION
This fixes three bugs in commit `2b6c8acd6f40c783494d747ee1b991fa03432cdf`:
* The scipy version is now updated so it works with Python 3.9, since the Python version was dropped in pyproject.toml
* `templates/**/*` is added to the installed package files
* The Makefile dependencies are specified, so that `make -j` works when compiling the generated Fortran code