### PR TITLE
Replace KROME fortran- and FLASH-specific syntax with sympy variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.0.0",
-    "scipy>=1.14.0",
+    "scipy>=1.13.0",
     "sympy>=1.14.0",
     "tqdm>=4.67.1",
     "h5py>=3.9.0",
@@ -52,4 +52,4 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-jaff = ["data/*.dat"]
+jaff = ["data/*.dat", "templates/**/*"]

--- a/src/jaff/templates/fortran_dlsodes/Makefile
+++ b/src/jaff/templates/fortran_dlsodes/Makefile
@@ -53,6 +53,27 @@ obj_main = main.o
 all:	$(objs) $(obj_main)
 	$(fc) $(fswitch) $(objs) $(obj_main) -o $(exe) $(lib)
 
+# Module dependencies
+# commons module is used by reactions, fluxes, ode, and main
+reactions.o: reactions.f90 commons.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# fluxes module uses commons and reactions
+fluxes.o: fluxes.f90 commons.o reactions.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# ode module uses commons and fluxes
+ode.o: ode.f90 commons.o fluxes.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# main uses commons and ode
+main.o: main.f90 commons.o ode.o
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
+# commons has no dependencies
+commons.o: commons.f90
+	$(fc) $(fswitch) -c $< -o $@ $(lib)
+
 #full debug target
 debug: fswitch = $(switchDBG)
 debug: all


### PR DESCRIPTION
This PR replaces KROME's Fortran- and FLASH-specific syntax, for example referring to the H2 number density as `n(idx_h2)`, with generic SymPy variables so that automatic code generation will work. This does _not_ yet solve the problem of undefined special functions such as `fselfH2` and `fHnOj`.