### PR TITLE
Allows metaspecies with names like CHx and OHx

### DIFF
--- a/src/jaff/species.py
+++ b/src/jaff/species.py
@@ -45,6 +45,8 @@ class Species:
             pname = pname.replace(a, "$" + proxy[a] + "$")
 
         def is_number(s):
+            if s == 'x':
+                return True
             try:
                 float(s)
                 return True
@@ -58,7 +60,8 @@ class Species:
             if not is_number(p):
                 expl += [p]
             else:
-                expl += [pold] * max(int(p)-1, 1)
+                if p != 'x':
+                    expl += [pold] * max(int(p)-1, 1)
             pold = p
         self.exploded = sorted([proxy_rev[x] for x in expl])
         self.mass = sum([mass_dict[x] for x in self.exploded])


### PR DESCRIPTION
This PR allows JAFF to parse networks that include metaspecies like CHx and OHx. These are treated as equivalent to just CH and OH for purposes of checking conservation, etc., but the original name is preserved.