### PR TITLE
fix: correct typo in path_template for python_solve_ivp plugin

### DIFF
--- a/src/jaff/plugins/python_solve_ivp/plugin.py
+++ b/src/jaff/plugins/python_solve_ivp/plugin.py
@@ -23,4 +23,4 @@ def main(network, path_template, path_build=None):
 
 if __name__ == "__main__":
     net = Network("networks/test.dat")
-    main(net, path_template="src/jaff/templates/preproncessor/python_solve_ivp")
+    main(net, path_template="src/jaff/templates/preprocessor/python_solve_ivp")


### PR DESCRIPTION
Resolves #65.

## Description
This PR corrects the misspelled directory name (`preproncessor` -> `preprocessor`) in the `__main__` block of the `python_solve_ivp` plugin.