### PR TITLE
[WIP] Separate production and destruction rhs

### DIFF
--- a/src/jaff/codegen/_template_engine.py
+++ b/src/jaff/codegen/_template_engine.py
@@ -1356,6 +1356,14 @@ class TemplateParser:
                         "func": lambda **kwargs: self.cg.get_indexed_qss_rhs(**kwargs),
                         "vars": ["idx", "rhs", "cse"],
                     },
+                    # Returns: IndexedReturn - QSS radiation moment RHS split
+                    # as production/destruction pairs at absolute QSS indices.
+                    "qss_rad_rhses": {
+                        "func": lambda **kwargs: self.cg.get_indexed_qss_radodes(
+                            **kwargs
+                        ),
+                        "vars": ["idx", "rhs", "cse"],
+                    },
                     # Returns: IndexedReturn - Jacobian matrix elements with optional CSE
                     # USE_DEDT TRUE/FALSE can be passed for this prop in templated syntax
                     "jacobian": {

--- a/src/jaff/codegen/_template_engine.py
+++ b/src/jaff/codegen/_template_engine.py
@@ -1350,6 +1350,12 @@ class TemplateParser:
                         "func": lambda **kwargs: self.cg.get_indexed_rhs(**kwargs),
                         "vars": ["idx", "rhs", "cse"],
                     },
+                    # Returns: IndexedReturn - QSS production/destruction RHS split
+                    # ordered as species production, species destruction pairs.
+                    "qss_rhses": {
+                        "func": lambda **kwargs: self.cg.get_indexed_qss_rhs(**kwargs),
+                        "vars": ["idx", "rhs", "cse"],
+                    },
                     # Returns: IndexedReturn - Jacobian matrix elements with optional CSE
                     # USE_DEDT TRUE/FALSE can be passed for this prop in templated syntax
                     "jacobian": {

--- a/src/jaff/codegen/codegen.py
+++ b/src/jaff/codegen/codegen.py
@@ -948,6 +948,158 @@ class Codegen:
 
         return ode_code
 
+    def get_indexed_qss_rhs(
+        self,
+        use_cse: bool = True,
+        cse_var: str = "cse",
+    ) -> IndexedReturn:
+        """Return stoichiometric QSS production/destruction RHS expressions.
+
+        QSS integrators need nonnegative production and destruction
+        accumulators separately instead of only the net derivative. For each
+        reaction flux ``F_j`` and species ``i`` this emits
+
+        ``f_plus_i  += product_stoich[j, i] * F_j``
+        ``f_minus_i += reactant_stoich[j, i] * F_j``
+
+        The output is ordered as ``[plus_0, minus_0, plus_1, minus_1, ...]``.
+        Repeated reactants or products are therefore preserved as integer
+        stoichiometric coefficients before any algebraic simplification or CSE.
+
+        Parameters
+        ----------
+        use_cse : bool, optional
+            Apply SymPy CSE across all split expressions. Default ``True``.
+        cse_var : str, optional
+            Prefix for CSE temporary variable names. Default ``"cse"``.
+
+        Returns
+        -------
+        IndexedReturn
+            Dictionary with CSE temporaries under ``extras["cse"]`` and one
+            expression per QSS RHS slot under ``expressions``.
+        """
+        with jaff_progress.indeterminate("Generating QSS rhs equations"):
+            ir: IndexedReturn = {
+                "extras": {"cse": IndexedList()},
+                "expressions": IndexedList(),
+            }
+
+            fluxes = self.net.sfluxes()
+            nspec = self.net.species.count
+            f_plus = [sp.Float(0.0) for _ in range(nspec)]
+            f_minus = [sp.Float(0.0) for _ in range(nspec)]
+
+            for reaction_idx, flux in enumerate(fluxes):
+                for species_idx in range(nspec):
+                    product_count = int(
+                        self.net.product_matrix[reaction_idx, species_idx]
+                    )
+                    reactant_count = int(
+                        self.net.reactant_matrix[reaction_idx, species_idx]
+                    )
+
+                    if product_count:
+                        f_plus[species_idx] += product_count * flux
+                    if reactant_count:
+                        f_minus[species_idx] += reactant_count * flux
+
+            qss_symbols = []
+            for species_idx in range(nspec):
+                qss_symbols.extend([f_plus[species_idx], f_minus[species_idx]])
+
+        if use_cse:
+            with jaff_progress.indeterminate("Generating QSS cse expressions"):
+                cse_symbols = sp.numbered_symbols(prefix=cse_var)
+                replacements, reduced_exprs = sp.cse(qss_symbols, symbols=cse_symbols)
+
+                replacements = self.__prune_cse(replacements, reduced_exprs)
+
+                pattern = re.compile(r"(\d+)")
+                for var, expr in replacements:
+                    match = pattern.search(str(var))
+                    idx: int = int(match.group(0)) if match is not None else 0
+                    expr = self.code_gen(expr, strict=False, allow_unknown_functions=True)
+                    ir["extras"]["cse"].append(IndexedValue([idx], expr))
+
+                qss_symbols = reduced_exprs
+
+        for i, expr in enumerate(
+            jaff_progress.track(qss_symbols, description="Generating QSS RHS code")
+        ):
+            expr = self.code_gen(expr, strict=False, allow_unknown_functions=True)
+            ir["expressions"].append(IndexedValue([i], expr))
+
+        return ir
+
+    def get_qss_rhs_str(
+        self,
+        idx_offset: int = 0,
+        use_cse: bool = True,
+        cse_var: str = "cse",
+        ode_var: str = "f",
+        brac_format: str = "",
+        def_prefix: str = "",
+        assignment_op: str = "",
+        line_end: str = "",
+    ) -> str:
+        """Generate QSS production/destruction RHS assignment code.
+
+        The emitted assignments use the same ordering as
+        :meth:`get_indexed_qss_rhs`: production and destruction slots are
+        interleaved for each species.
+
+        Parameters
+        ----------
+        idx_offset : int, optional
+            Base index for output array subscripts. Default ``0``.
+        use_cse : bool, optional
+            Enable CSE across split expressions. Default ``True``.
+        cse_var : str, optional
+            Prefix for CSE temporary variable names. Default ``"cse"``.
+        ode_var : str, optional
+            Name of the output RHS array. Default ``"f"``.
+        brac_format : str, optional
+            Override 1-D bracket style. Empty string uses the language default.
+        def_prefix : str, optional
+            Type declaration prefix for CSE temporaries. Empty string uses the
+            language-default type qualifier and ``double`` type.
+        assignment_op : str, optional
+            Assignment operator override. Empty string uses the language default.
+        line_end : str, optional
+            Line terminator override. Empty string uses the language default.
+
+        Returns
+        -------
+        str
+            Multi-line string of QSS RHS assignments, including CSE temporaries.
+        """
+        ioff = idx_offset if idx_offset >= 0 else self.ioff
+        prefix = (
+            def_prefix
+            or f"{self.extras.get('type_qualifier', '')}{self.types.get('double', '')}"
+        )
+        lb, rb = brac_format or (self.lb, self.rb)
+        assign_op = assignment_op or self.assignment_op
+        lend = line_end or self.line_end
+
+        qss_code = ""
+        qss_expressions = self.get_indexed_qss_rhs(
+            use_cse=use_cse,
+            cse_var=cse_var,
+        )
+
+        if use_cse:
+            for idx, expression in qss_expressions["extras"]["cse"]:
+                _idx = idx[0]
+                qss_code += f"{prefix}{cse_var}{_idx} {assign_op} {expression}{lend}\n"
+
+        for idx, expression in qss_expressions["expressions"]:
+            _idx = idx[0]
+            qss_code += f"{ode_var}{lb}{ioff + _idx}{rb} {assign_op} {expression}{lend}\n"
+
+        return qss_code
+
     def get_indexed_rhs(
         self,
         use_cse: bool = True,

--- a/src/jaff/codegen/codegen.py
+++ b/src/jaff/codegen/codegen.py
@@ -1100,6 +1100,103 @@ class Codegen:
 
         return qss_code
 
+    def get_indexed_qss_radodes(
+        self,
+        order: int = 0,
+        use_cse: bool = True,
+        cse_var: str = "cse",
+    ) -> IndexedReturn:
+        """Return QSS production/destruction RHS expressions for radiation moments.
+
+        Radiation QSS slots follow the same ``plus, minus`` split used for
+        species and energy equations.  The returned indices are absolute
+        zero-based positions in the ``2 * neqs`` QSS output array, so the
+        radiation entries begin after all species pairs and the energy pair.
+        """
+        ir: IndexedReturn = {
+            "extras": {"cse": IndexedList()},
+            "expressions": IndexedList(),
+        }
+
+        rad = self.net.radiation
+        if rad is None:
+            return ir
+
+        if order not in [0, 1, 2, 3]:
+            raise ValueError("Invalid order: Supported orders are 0, 1, 2, 3")
+
+        nden = sp.MatrixSymbol("nden", self.net.species.count, 1)
+        den = sp.MatrixSymbol(
+            "radeden" if rad.energy_density else "photden",
+            rad.nbands,
+            1,
+        )
+        rflux = sp.MatrixSymbol("rflux", rad.nbands, 1)
+        flux_map = {den[sp.Idx(i)]: rflux[sp.Idx(i)] for i in range(rad.nbands)}
+
+        rad_plus = [sp.Float(0.0) for _ in range(2 * rad.nbands)]
+        rad_minus = [sp.Float(0.0) for _ in range(2 * rad.nbands)]
+
+        for group in rad.groups:
+            density_production = sp.Float(0.0)
+            density_destruction = sp.Float(0.0)
+            flux_destruction = sp.Float(0.0)
+
+            for reaction, props in group.props.items():
+                destruction_rate = props["k"]
+                density_production += (
+                    props["k"]
+                    * props["delta_rad"]
+                    / (1 if rad.energy_density else (group.eavg or 1))
+                )
+
+                for reactant in reaction.reactants:
+                    species_idx = self.net.species[str(reactant)].index
+                    destruction_rate *= nden[sp.Idx(species_idx)]
+
+                density_destruction += destruction_rate
+                flux_destruction += destruction_rate.xreplace(flux_map)
+
+            density_idx, flux_idx = rad.ordered_index(group.index, order)
+            rad_plus[density_idx] = density_production
+            rad_minus[density_idx] = density_destruction
+            rad_minus[flux_idx] = flux_destruction
+
+        qss_symbols = []
+        qss_indices = []
+        nspec = self.net.species.count
+        for rad_idx in range(2 * rad.nbands):
+            qss_slot = 2 * (nspec + 1 + rad_idx)
+            qss_indices.extend([qss_slot, qss_slot + 1])
+            qss_symbols.extend([rad_plus[rad_idx], rad_minus[rad_idx]])
+
+        if use_cse:
+            with jaff_progress.indeterminate("Generating QSS radiation cse expressions"):
+                cse_symbols = sp.numbered_symbols(prefix=cse_var)
+                replacements, reduced_exprs = sp.cse(qss_symbols, symbols=cse_symbols)
+
+                replacements = self.__prune_cse(replacements, reduced_exprs)
+
+                pattern = re.compile(r"(\d+)")
+                for var, expr in replacements:
+                    match = pattern.search(str(var))
+                    idx: int = int(match.group(0)) if match is not None else 0
+                    expr = self.code_gen(expr, strict=False, allow_unknown_functions=True)
+                    ir["extras"]["cse"].append(IndexedValue([idx], expr))
+
+                qss_symbols = reduced_exprs
+
+        for qss_idx, expr in zip(
+            qss_indices,
+            jaff_progress.track(
+                qss_symbols, description="Generating QSS radiation RHS code"
+            ),
+        ):
+            expr = self.code_gen(expr, strict=False, allow_unknown_functions=True)
+            ir["expressions"].append(IndexedValue([qss_idx], expr))
+
+        return ir
+
     def get_indexed_rhs(
         self,
         use_cse: bool = True,

--- a/src/jaff/plugins/microphysics/plugin.py
+++ b/src/jaff/plugins/microphysics/plugin.py
@@ -21,6 +21,14 @@ def main(
         brac_format="()",
         ode_var="ydot",
     )
+    qss_ode = cg.get_qss_rhs_str(
+        idx_offset=1,
+        use_cse=True,
+        cse_var="qss_cse",
+        def_prefix="const amrex::Real ",
+        brac_format="()",
+        ode_var="ydot",
+    )
     jac = cg.get_jacobian_str(
         idx_offset=1,
         use_dedt=True,
@@ -30,7 +38,22 @@ def main(
         matrix_format="(,)",
     )
     ode = re.sub(r"nden\[\s*(\d+)\s*\]", r"nden(\1)", ode)
+    qss_ode = re.sub(r"nden\[\s*(\d+)\s*\]", r"nden(\1)", qss_ode)
     jac = re.sub(r"nden\[\s*(\d+)\s*\]", r"nden(\1)", jac)
+    qss_dedt = re.sub(
+        r"nden\[\s*(\d+)\s*\]",
+        r"nden(\1)",
+        cg.get_dedt(),
+    )
+    qss_ode += f"const amrex::Real qss_dedt = {qss_dedt} / state.rho;\n"
+    qss_ode += (
+        f"ydot({2 * network.species.count + 1}) = "
+        "amrex::max(qss_dedt, amrex::Real(0.0));\n"
+    )
+    qss_ode += (
+        f"ydot({2 * network.species.count + 2}) = "
+        "amrex::max(-qss_dedt, amrex::Real(0.0));\n"
+    )
 
     electron_found = False
     for i, specie in enumerate(network.species):
@@ -54,6 +77,7 @@ def main(
         {
             "ODE": ode,
             "JACOBIAN": jac,
+            "QSS_ODE": qss_ode,
         },
     ]
 

--- a/src/jaff/templates/generator/microphysics/actual_rhs.H
+++ b/src/jaff/templates/generator/microphysics/actual_rhs.H
@@ -424,6 +424,10 @@ actual_rhs_qss(const burn_t &state, amrex::Array1D<amrex::Real, 1, 2 * neqs> &yd
   ydot(2 * ($nspec$ + 1) - 1) = amrex::max(qss_dedt, amrex::Real(0.0));
   ydot(2 * ($nspec$ + 1)) = amrex::max(-qss_dedt, amrex::Real(0.0));
   // $JAFF END
+  // $JAFF REPEAT idx, rhs, cse IN qss_rad_rhses $[REPLACE radeden\[\s*(\d+)\s*\] state.rn[\1] REPLACE photden\[\s*(\d+)\s*\] state.rn[\1] REPLACE rflux\[\s*(\d+)\s*\] state.rn[2*\1+1] REPLACE nden\[\s*(\d+)\s*\] state.xn[\1]]$
+  const amrex::Real qss_rad_cse$idx$ = $cse$;
+  ydot($idx+1$) = $rhs$;
+  // $JAFF END
 }
 
 template <class MatrixType>

--- a/src/jaff/templates/generator/microphysics/actual_rhs.H
+++ b/src/jaff/templates/generator/microphysics/actual_rhs.H
@@ -382,6 +382,50 @@ actual_rhs(const burn_t &state, amrex::Array1D<amrex::Real, 1, neqs> &ydot) {
   // $JAFF END
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_INLINE void
+actual_rhs_qss(const burn_t &state, amrex::Array1D<amrex::Real, 1, 2 * neqs> &ydot) {
+
+  using namespace Rates;
+
+  amrex::Real tgas = state.T;
+
+  amrex::Array1D<amrex::Real, 0, NumSpec - 1> nden;
+      for (int i = 0; i < NumSpec; ++i) {
+      nden(i) = state.xn[i];
+      }
+  amrex::Real l0_co_interp1d = l0_co_interp1d_func(state);
+  amrex::Real llte_co_interp2d = llte_co_interp2d_func(state, nden);
+  amrex::Real psigd_coll_interp2d = psigd_coll_interp2d_func(state, nden);
+  amrex::Real alpha_co_interp2d = alpha_co_interp2d_func(state, nden);
+  amrex::Real nhalf_co_interp2d = nhalf_co_interp2d_func(state, nden);
+
+
+  amrex::Real crate = network_rp::crate;
+  amrex::Real av = network_rp::Av;
+  amrex::Real d2g = network_rp::dust2gas_ratio;
+  amrex::Real chi = network_rp::chi;
+
+  const double Leff_CO_max_ = 3.0e20; //Maximum CO cooling length. default 100pc.
+  const double gradv_ =  3 * 3e-14; //1.0e-14 = 0.3km/s /pc*/
+  const double kb_ = 1.380649e-16; // Boltzmann constant in erg/K
+  const double mCO_ = 4.68e-23; // mass of CO molecule
+  const double vth = sqrt(2. * kb_ * tgas / mCO_);
+
+  const double grad_small = vth / Leff_CO_max_;
+  const double gradeff = std::max(gradv_, grad_small);
+  const double gradv = gradeff;
+
+  // $JAFF REPEAT idx, rhs, cse IN qss_rhses $[REPLACE radeden\[\s*(\d+)\s*\] state.rn[\1] REPLACE photden\[\s*(\d+)\s*\] state.rn[\1] REPLACE rflux\[\s*(\d+)\s*\] state.rn[2*\1+1] REPLACE nden\[\s*(\d+)\s*\] state.xn[\1]]$
+  const amrex::Real qss_cse$idx$ = $cse$;
+  ydot($idx+1$) = $rhs$;
+  // $JAFF END
+  // $JAFF SUB nspec, dedt $[REPLACE radeden\[\s*(\d+)\s*\] state.rn[\1] REPLACE photden\[\s*(\d+)\s*\] state.rn[\1] REPLACE rflux\[\s*(\d+)\s*\] state.rn[2*\1+1] REPLACE nden\[\s*(\d+)\s*\] state.xn[\1]]$
+  const amrex::Real qss_dedt = $dedt$ / state.rho;
+  ydot(2 * ($nspec$ + 1) - 1) = amrex::max(qss_dedt, amrex::Real(0.0));
+  ydot(2 * ($nspec$ + 1)) = amrex::max(-qss_dedt, amrex::Real(0.0));
+  // $JAFF END
+}
+
 template <class MatrixType>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE void
 jac_chem(const burn_t &state, MatrixType &jac) {

--- a/src/jaff/templates/preprocessor/microphysics/actual_rhs.H
+++ b/src/jaff/templates/preprocessor/microphysics/actual_rhs.H
@@ -41,6 +41,31 @@ actual_rhs(burn_t &state, amrex::Array1D<amrex::Real, 1, neqs> &ydot) {
   rhs_specie(state, ydot, nden);
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_INLINE void
+rhs_specie_qss(const burn_t &state, amrex::Array1D<amrex::Real, 1, 2 * neqs> &ydot,
+               const amrex::Array1D<amrex::Real, 0, NumSpec - 1> &nden) {
+
+  using namespace Rates;
+
+  amrex::Real tgas = state.T;
+  amrex::Real crate = 0.0; // placeholder
+  amrex::Real av = 0.0;    // placeholder
+
+  // PREPROCESS_QSS_ODE
+  // PREPROCESS_END
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE void
+actual_rhs_qss(const burn_t &state, amrex::Array1D<amrex::Real, 1, 2 * neqs> &ydot) {
+
+  amrex::Array1D<amrex::Real, 0, NumSpec - 1> nden;
+  for (int i = 0; i < NumSpec; ++i) {
+    nden(i) = state.xn[i];
+  }
+
+  rhs_specie_qss(state, ydot, nden);
+}
+
 template <class MatrixType>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE void
 jac_chem(const burn_t &state, MatrixType &jac,

--- a/tests/test_ode_and_jac.py
+++ b/tests/test_ode_and_jac.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import List
 
 import pytest
+import sympy as sp
 
-from jaff.codegen import Codegen
 from jaff import Network
+from jaff.codegen import Codegen, TemplateParser
 
 
 @pytest.fixture
@@ -127,6 +128,46 @@ def test_qss_rhs_uses_stoichiometric_split(tmp_path):
     ]
 
     assert qss_comp == expected_qss_rhs
+
+
+def test_microphysics_qss_template_emits_radiation_split_slots(tmp_path):
+    """Radiation QSS slots are emitted as production/destruction pairs."""
+
+    network_file = tmp_path / "test_qss_radiation.dat"
+    network_file.write_text("@format:idx, R, R, P, rate\n1, H, H, H2, 1.0\n")
+
+    network = Network(
+        str(network_file),
+        funcfile="none",
+        rad_bands=[1.0, 2.0],
+        _from_cli=True,
+    )
+    assert network.radiation is not None
+
+    photden = sp.MatrixSymbol("photden", 1, 1)
+    network.radiation.groups[0].props[network.reactions[0]] = {
+        "k": 2 * photden[sp.Idx(0)],
+        "delta_rad": sp.Float(3.0),
+    }
+
+    template_file = (
+        Path(__file__).parent.parent
+        / "src"
+        / "jaff"
+        / "templates"
+        / "generator"
+        / "microphysics"
+        / "actual_rhs.H"
+    )
+    generated = TemplateParser(network, template_file).parse_file()
+    qss_body = generated.split("actual_rhs_qss", 1)[1].split(
+        "template <class MatrixType>", 1
+    )[0]
+
+    assert "ydot(7) = 6.0*state.rn[0];" in qss_body
+    assert "ydot(8) = qss_rad_cse0*state.rn[0];" in qss_body
+    assert "ydot(9) = 0.0;" in qss_body
+    assert "ydot(10) = qss_rad_cse0*state.rn[2*0+1];" in qss_body
 
 
 def test_network_reactions_loaded_dedt(test_network_dedt: Network):

--- a/tests/test_ode_and_jac.py
+++ b/tests/test_ode_and_jac.py
@@ -107,6 +107,28 @@ def test_ode_and_jac(test_codegen: Codegen):
         assert comp == excomp, f"Jacobian: {comp} must be equal to {excomp}"
 
 
+def test_qss_rhs_uses_stoichiometric_split(tmp_path):
+    """QSS RHS keeps production and destruction terms separate by stoichiometry."""
+
+    network_file = tmp_path / "test_qss.dat"
+    network_file.write_text("@format:idx, R, R, P, rate\n1, H, H, H2, 1.0\n")
+
+    cg = Codegen(Network(str(network_file)), lang="c++")
+    qss_rhs = cg.get_qss_rhs_str(use_cse=False)
+
+    qss_comp = qss_rhs.strip().split("\n")
+    qss_comp = [comp.split("=")[-1].strip().strip(";") for comp in qss_comp]
+
+    expected_qss_rhs = [
+        "0.0",
+        "2.0*std::pow(nden[0], 2)",
+        "1.0*std::pow(nden[0], 2)",
+        "0.0",
+    ]
+
+    assert qss_comp == expected_qss_rhs
+
+
 def test_network_reactions_loaded_dedt(test_network_dedt: Network):
     """Test that the test network loads with expected reactions."""
 


### PR DESCRIPTION
Generates code that separately computes production and destruction rates, so it produces a "production" rhs and a "destruction" rhs, which has terms on the right hand side separately by stoichiometry for each species.

This is requied to:
* separate out species that are in partial equilibrium from those that aren't, or
* use the alpha-QSS/CHEMEQ2 integrator that exploits the special stiffness structure of kinetics ODEs (https://apps.dtic.mil/sti/html/tr/ADA392490/)
  * Note: this method does NOT preserve linear invariants by construction.